### PR TITLE
Added the way to disable Crowdin Popup (BO/FO)

### DIFF
--- a/js/livetranslation.js
+++ b/js/livetranslation.js
@@ -1,5 +1,8 @@
 var _jipt = [];
 _jipt.push(['project', 'prestashop-official']);
+_jipt.push(['escape', function() {
+  window.location.href = urlLiveTranslationEscape;
+}]);
 (function()
 {
   var script = document.createElement('script');

--- a/ps_livetranslation.php
+++ b/ps_livetranslation.php
@@ -168,7 +168,18 @@ class Ps_Livetranslation extends Module
     public function hookDisplayHeader($params)
     {
         if ($this->isLiveTranslationActive()) {
-            $this->context->controller->registerJavascript('modules-livetranslation', 'modules/'.$this->name.'/js/livetranslation.js', ['position' => 'bottom', 'priority' => 110]);
+            $this->context->controller->registerJavascript(
+                'modules-livetranslation',
+                'modules/'.$this->name.'/js/livetranslation.js',
+                [
+                    'position' => 'bottom',
+                    'priority' => 110
+                ]
+            );
+            $defaultLanguage = new Language((int)Configuration::get('PS_LANG_DEFAULT'));
+            Media::addJsDef([
+                'urlLiveTranslationEscape' => $this->context->link->getBaseLink($this->context->shop->id).$defaultLanguage->iso_code.'/?disable_live_translation=1',
+            ]);
         }
     }
 
@@ -189,6 +200,17 @@ class Ps_Livetranslation extends Module
     {
         if ($this->isLiveTranslationActive()) {
             $this->context->controller->addJS($this->_path.'js/livetranslation.js', 'all');
+            Media::addJsDef([
+                'urlLiveTranslationEscape' => $this->context->link->getAdminLink(
+                    'AdminModules',
+                    true,
+                    null,
+                    [
+                        'configure' => $this->name,
+                        'disable_live_translation' => 1
+                    ]
+                ),
+            ]);
         }
     }
 


### PR DESCRIPTION
Fixed #4 

Test Scenario :
* Go the configure page
* Don't be logged to Crowdin
* Click to the button "BackOffice Translate"
* Don't log to Crowdin
* **BEFORE :** You have no way to quit the translation mode
* **AFTER :** Click on the :x: button on the top right and you go back to the admin page
* Click to the button "FrontOffice Translate"
* Don't log to Crowdin
* **BEFORE :** You have no way to quit the translation mode
* **AFTER :** Click on the :x: button on the top right and you go back to the frontoffice page